### PR TITLE
Put two section per row for tracked courses and add remove and enroll actions

### DIFF
--- a/src/components/TrackedCourses/TrackedCourseCard.css
+++ b/src/components/TrackedCourses/TrackedCourseCard.css
@@ -96,6 +96,8 @@ button:hover {
 }
 
 .enroll-button {
+  text-align: center;
+  text-decoration: none;
   font-weight: 500;
   font-size: 12px;
   color: #FFFFFF;

--- a/src/components/TrackedCourses/TrackedCourseCard.css
+++ b/src/components/TrackedCourses/TrackedCourseCard.css
@@ -20,7 +20,7 @@
 }
 
 .section-label {
-  color: #1B1F23;
+  color: #6A737D;
   font-weight: 600;
   font-size: 16px;
   padding: 4px 12px;
@@ -52,7 +52,7 @@
 }
 
 .status-icon {
-  margin: 32px 10px 20px 0px;
+  margin: 32px 20px 20px 10px;
 }
 
 .course-info-view {

--- a/src/components/TrackedCourses/TrackedCourseCard.css
+++ b/src/components/TrackedCourses/TrackedCourseCard.css
@@ -1,12 +1,14 @@
 .tracked-course-card {
-  width: 60%;
-  margin: auto;
   background: #FFFFFF;
   border: 1px solid #D1D5DA;
   box-sizing: border-box;
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.1);
   border-radius: 4px;
-  margin-bottom: 20px;
+  margin: 0 15px 20px 15px;
+  flex-basis: 45%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .title-label {
@@ -50,7 +52,7 @@
 }
 
 .status-icon {
-  margin: 32px 30px 20px 20px;
+  margin: 32px 10px 20px 0px;
 }
 
 .course-info-view {

--- a/src/components/TrackedCourses/TrackedCourseCard.tsx
+++ b/src/components/TrackedCourses/TrackedCourseCard.tsx
@@ -7,19 +7,19 @@ import { untrackSection } from '../../utils/requests';
 
 export interface TrackedCourseCardProps {
   section: Section
-  untrackedSectionHandler: (courseId: number) => void
+  untrackSectionHandler: (courseId: number) => void
 }
 
 const TrackedCourseCard: React.FunctionComponent<TrackedCourseCardProps> = ({
   section,
-  untrackedSectionHandler
+  untrackSectionHandler
 }) => {
 
   const untrackClicked = async () => {
     try {
       const data = await untrackSection(section.catalogNum)
       if (data) {
-        untrackedSectionHandler(section.catalogNum)
+        untrackSectionHandler(section.catalogNum)
       }
     } catch (err) {
       console.log(err)

--- a/src/components/TrackedCourses/TrackedCourseCard.tsx
+++ b/src/components/TrackedCourses/TrackedCourseCard.tsx
@@ -3,14 +3,29 @@ import React from 'react'
 import './TrackedCourseCard.css'
 
 import { Section, Status } from '../../types'
+import { untrackSection } from '../../utils/requests';
 
 export interface TrackedCourseCardProps {
   section: Section
+  untrackedSectionHandler: (courseId: number) => void
 }
 
 const TrackedCourseCard: React.FunctionComponent<TrackedCourseCardProps> = ({
-  section
+  section,
+  untrackedSectionHandler
 }) => {
+
+  const untrackClicked = async () => {
+    try {
+      const data = await untrackSection(section.catalogNum)
+      if (data) {
+        untrackedSectionHandler(section.catalogNum)
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
   const statusIcon = (status: Status) => {
     switch (status) {
       case Status.OPEN:
@@ -45,10 +60,10 @@ const TrackedCourseCard: React.FunctionComponent<TrackedCourseCardProps> = ({
         <p className="mode-label">{section.mode}</p>
       </div>
       <div className="action-buttons">
-        <button className="remove-button" >REMOVE</button>
+        <button className="remove-button" onClick={untrackClicked}>REMOVE</button>
         {
           section.status === Status.OPEN
-            ? <button className="enroll-button">ENROLL</button>
+            ? <a className="enroll-button" href="https://studentcenter.cornell.edu">ENROLL</a>
             : null
         }
       </div>

--- a/src/components/TrackedCourses/TrackedCourseCard.tsx
+++ b/src/components/TrackedCourses/TrackedCourseCard.tsx
@@ -30,19 +30,19 @@ const TrackedCourseCard: React.FunctionComponent<TrackedCourseCardProps> = ({
     switch (status) {
       case Status.OPEN:
         return (
-          <svg className="status-icon" height="16" width="16">
+          <svg height="16" width="16">
             <circle cx="8" cy="8" r="8" fill="#47C753" />
           </svg>
         )
       case Status.CLOSED:
         return (
-          <svg className="status-icon" height="16" width="16">
+          <svg height="16" width="16">
             <rect width="16" height="16" fill="#CA4238" />
           </svg>
         )
       case Status.WAITLISTED:
         return (
-          <svg className="status-icon" height="16" width="16">
+          <svg height="16" width="16">
             <polygon points="0,16 8,0 16,16" fill="#FFD027" />
           </svg>
         )
@@ -52,7 +52,9 @@ const TrackedCourseCard: React.FunctionComponent<TrackedCourseCardProps> = ({
     <div className="tracked-course-card" >
       <div className="title-status-view">
         <p className="title-label">{section.title}</p>
-        {statusIcon(section.status)}
+        <div className="status-icon">
+          {statusIcon(section.status)}
+        </div>
       </div>
       <div className="course-info-view">
         <p className="section-label">{section.section}</p>

--- a/src/components/TrackedCourses/TrackedCoursesView.css
+++ b/src/components/TrackedCourses/TrackedCoursesView.css
@@ -1,6 +1,10 @@
 .tracked-courses-view {
-  text-align: center;
+  text-align: left;
   margin: 60px 0;
+}
+
+.no-tracked-course {
+  text-align: center;
 }
 
 .tracking-title-label {
@@ -15,17 +19,26 @@
 }
 
 .num-available-label {
-  width: 60%;
+  width: 80%;
   color: #47C753;
   font-weight: 600;
   font-size: 24px;
+  padding-left: 30px;
   margin: 10px auto;
 }
 
 .num-awaiting-label {
-  width: 60%;
+  width: 80%;
   color: #050505;
   font-weight: 600;
   font-size: 24px;
+  padding-left: 30px;
   margin: 30px auto 10px auto;
+}
+
+.all-tracked-courses {
+  margin: auto;
+  width: 80%;
+  display: flex;
+  flex-wrap: wrap;
 }

--- a/src/components/TrackedCourses/TrackedCoursesView.tsx
+++ b/src/components/TrackedCourses/TrackedCoursesView.tsx
@@ -37,15 +37,32 @@ class TrackedCoursesView extends React.Component {
     }
   }
 
+  updateSections = async (courseId: number) => {
+    const updatedAvailableSections = this.state.availableSections.filter(section => section.catalogNum != courseId)
+    const updatedAwaitingSections = this.state.awaitingSections.filter(section => section.catalogNum != courseId)
+    this.setState({
+      availableSections: updatedAvailableSections,
+      awaitingSections: updatedAwaitingSections
+    })
+  }
+
   render() {
     const availableSectionsView = this.state.availableSections.map(section => {
       return (
-        <TrackedCourseCard section={section} />
+        <TrackedCourseCard
+          key={section.catalogNum}
+          section={section}
+          untrackedSectionHandler={(courseId) => this.updateSections(courseId)}
+        />
       )
     })
     const awaitingSections = this.state.awaitingSections.map(section => {
       return (
-        <TrackedCourseCard section={section} />
+        <TrackedCourseCard
+          key={section.catalogNum}
+          section={section}
+          untrackedSectionHandler={(courseId) => this.updateSections(courseId)}
+        />
       )
     })
     const sections = () => {

--- a/src/components/TrackedCourses/TrackedCoursesView.tsx
+++ b/src/components/TrackedCourses/TrackedCoursesView.tsx
@@ -61,7 +61,7 @@ class TrackedCoursesView extends React.Component {
         <TrackedCourseCard
           key={section.catalogNum}
           section={section}
-          untrackSectionHandler={(courseId) => this.updateSections(courseId)}
+          untrackSectionHandler={courseId => this.updateSections(courseId)}
         />
       )
     })

--- a/src/components/TrackedCourses/TrackedCoursesView.tsx
+++ b/src/components/TrackedCourses/TrackedCoursesView.tsx
@@ -49,18 +49,20 @@ class TrackedCoursesView extends React.Component {
       )
     })
     const sections = () => {
-      if (this.state.availableSections.length > 0 && this.state.awaitingSections.length > 0) {
+      if (this.state.availableSections.length > 0 || this.state.awaitingSections.length > 0) {
         return (
           <div>
             <p className="num-available-label">{`${this.state.availableSections.length} Available`}</p>
-            {availableSectionsView}
+            <div className="all-tracked-courses">
+              {availableSectionsView}
+            </div>
             <p className="num-awaiting-label">{`${this.state.awaitingSections.length} Awaiting`}</p>
             {awaitingSections}
           </div>
         )
       } else {
         return (
-          <div>
+          <div className="no-tracked-course">
             <svg height="70" width="70">
               <circle cx="35" cy="35" r="35" fill="#47C753" />
             </svg>

--- a/src/components/TrackedCourses/TrackedCoursesView.tsx
+++ b/src/components/TrackedCourses/TrackedCoursesView.tsx
@@ -52,7 +52,7 @@ class TrackedCoursesView extends React.Component {
         <TrackedCourseCard
           key={section.catalogNum}
           section={section}
-          untrackedSectionHandler={(courseId) => this.updateSections(courseId)}
+          untrackSectionHandler={(courseId) => this.updateSections(courseId)}
         />
       )
     })
@@ -61,7 +61,7 @@ class TrackedCoursesView extends React.Component {
         <TrackedCourseCard
           key={section.catalogNum}
           section={section}
-          untrackedSectionHandler={(courseId) => this.updateSections(courseId)}
+          untrackSectionHandler={(courseId) => this.updateSections(courseId)}
         />
       )
     })

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -52,6 +52,9 @@ export const searchCourses = async (query: string) => {
 
 export const trackSection = async () => { }
 
-export const untrackSection = async () => { }
+export const untrackSection = async (courseId: number) => {
+    const data = await post(`/sections/untrack/`, { course_id: courseId })
+    return data
+}
 
 export const setNotificationMode = async () => { }

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -52,9 +52,6 @@ export const searchCourses = async (query: string) => {
 
 export const trackSection = async () => { }
 
-export const untrackSection = async (courseId: number) => {
-    const data = await post(`/sections/untrack/`, { course_id: courseId })
-    return data
-}
+export const untrackSection = async (courseId: number) => await post(`/sections/untrack/`, { course_id: courseId })
 
 export const setNotificationMode = async () => { }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
- Put two sections per row for currently tracked courses
- Add remove and enroll actions for tracked courses


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- Added some style changes so two sections are put in one row
- Integrated backend for remove/untrack course
- Redirect to student center if click enroll


## Test Coverage

<!-- Describe how you tested this feature. -->

Manually. 

## Screenshots 

<!-- This could include of screenshots of the new feature / proof that the changes work. -->


https://user-images.githubusercontent.com/48968041/116919311-16b73080-ac1f-11eb-8489-9fcc0c085fdb.mov
